### PR TITLE
Add kick-me command to simulate kick (self leave)

### DIFF
--- a/pkg/connector/commands.go
+++ b/pkg/connector/commands.go
@@ -208,7 +208,7 @@ var KickMeCommand = &commands.FullHandler{
 		changes := &bridgev2.ChatMemberList{MemberMap: bridgev2.ChatMemberMap{}}
 		changes.MemberMap.Set(bridgev2.ChatMember{
 			EventSender: bridgev2.EventSender{
-				IsFromMe:    false,
+				IsFromMe:    true,
 				SenderLogin: login.ID,
 				Sender:      networkid.UserID(login.ID),
 			},


### PR DESCRIPTION
## Summary
- Adds a new management-room command: `kick-me`.
- When run inside a portal room, emits a remote chat info change that sets the current user’s membership to `leave`.
- Intended for testing clients’ "kicked but room still exists" behavior (no chat deletion).

## Testing
- Manual: run `kick-me` in a dummybridge portal and verify the client receives a self leave membership event.