### PR TITLE
DROID-77263: fix empty-login boot-loop panic in dummybridge

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -117,7 +117,17 @@ func (dc *DummyClient) Connect(ctx context.Context) {
 			); errors.Is(err, context.Canceled) {
 				return
 			} else if err != nil {
-				panic(err)
+				// Never panic here: a persistent error (e.g. an empty login ID failing
+				// GetPortalByKey under split portals) would otherwise boot-loop crash the
+				// host app on every startup (DROID-77263). Report a bridge-state error and
+				// stop generating instead.
+				log.Err(err).Msg("Failed to generate portal after login")
+				dc.UserLogin.BridgeState.Send(status.BridgeState{
+					StateEvent: status.StateUnknownError,
+					Error:      "dummy-generate-portal-failed",
+					Message:    err.Error(),
+				})
+				return
 			}
 		}
 	}()

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"go.mau.fi/util/jsontime"
 	"go.mau.fi/util/random"
@@ -148,8 +149,17 @@ func (dl *DummyLogin) SubmitUserInput(ctx context.Context, input map[string]stri
 	if input["password"] == "incorrectpassword" {
 		return nil, fmt.Errorf("incorrect password")
 	}
+	username := input["username"]
+	if username == "" {
+		// The login form advertises "anything goes and it's used as the ID", so an empty
+		// username must keep working. Persisting a UserLogin with an empty ID is unsafe though:
+		// with split portals enabled, an empty receiver makes GetPortalByKey fail and crashes
+		// the host app on every startup (DROID-77263). Generate a random ID instead so the login
+		// ID can never be empty.
+		username = "dummy-" + strings.ToLower(random.String(12))
+	}
 	login, err := dl.User.NewLogin(ctx, &database.UserLogin{
-		ID:         networkid.UserLoginID(input["username"]),
+		ID:         networkid.UserLoginID(username),
 		RemoteName: input["password"],
 		RemoteProfile: status.RemoteProfile{
 			Name:  input["password"],


### PR DESCRIPTION
## Summary

Fixes a host-app boot-loop crash (DROID-77263) caused by logging into dummybridge with an **empty username**.

An empty username persisted a `UserLogin` with `ID == ""`. With split portals enabled (Beeper SDK local bridges), the portal-generation goroutine in `DummyClient.Connect` built a `PortalKey{Receiver: ""}`, and `Bridge.GetPortalByKey` rejected it with `receiver must always be set when split portals is enabled`. The goroutine's bare `panic(err)` then crashed the whole SDK process — and the host Android app — on **every** startup, since the bad login row persists.

This is the approved two-layer fix ("do changes 1+2 only"):

- **Change 1 — `pkg/connector/login.go`:** never persist an empty login ID. The login form advertises "anything goes and it's used as the ID", so an empty username is preserved by substituting a random ID rather than being rejected. This prevents an empty receiver at the source.
- **Change 2 — `pkg/connector/client.go`:** replace the bare `panic(err)` in the `Connect` goroutine with a logged error plus an `UNKNOWN_ERROR` bridge-state report, then `return`. Defense in depth — a bad/persistent login error can never crash the host app, including any pre-existing `ID == ""` logins already in the database.

## Testing

- `go build ./pkg/connector/...` passes; `go vet` and `gofmt` clean.

## Out of scope

Recovery of already-broken installs / upstream mautrix-go empty-ID validation (Change 3 in the triage plan) is intentionally not included, per the autofix directive.

Linear: https://linear.app/beeper/issue/DROID-77263

🤖 Generated with [Claude Code](https://claude.com/claude-code)